### PR TITLE
Codebase formatting

### DIFF
--- a/src/client_storytel_api.rs
+++ b/src/client_storytel_api.rs
@@ -1,5 +1,5 @@
 use crate::password_crypt;
-use serde::{Deserialize};
+use serde::Deserialize;
 
 pub struct ClientData {
     pub request_client: reqwest::blocking::Client,
@@ -44,37 +44,44 @@ pub struct Book {
 pub fn login(client_data: &mut ClientData, email: &str, pass: &str) {
     let hex_encryp_pass = password_crypt::encrypt_password(&pass.trim());
 
-    let url = format!("https://www.storytel.com/api/login.action\
+    let url = format!(
+        "https://www.storytel.com/api/login.action\
                       ?m=1&uid={}&pwd={}",
-                      email.trim(), hex_encryp_pass);
+        email.trim(),
+        hex_encryp_pass
+    );
 
-    let resp_login = client_data.request_client.get(&url)
-        .send();
+    let resp_login = client_data.request_client.get(&url).send();
 
     client_data.login_data = resp_login.unwrap().json::<Login>().unwrap()
 }
 
-pub fn get_bookshelf(client_data: &mut ClientData)
-                -> BookShelf {
-    let url_get_bookshelf = format!("https://www.storytel.com/api/getBookShelf.\
+pub fn get_bookshelf(client_data: &mut ClientData) -> BookShelf {
+    let url_get_bookshelf = format!(
+        "https://www.storytel.com/api/getBookShelf.\
                                     action?token={}",
-                                    client_data.login_data.account_info
-                                               .single_sign_token);
-    let resp_bookshelf = client_data.request_client.get(&url_get_bookshelf)
-        .send();
+        client_data.login_data.account_info.single_sign_token
+    );
+    let resp_bookshelf = client_data.request_client.get(&url_get_bookshelf).send();
 
     resp_bookshelf.unwrap().json::<BookShelf>().unwrap()
 }
 
 pub fn get_stream_url(client_data: &mut ClientData, id: &u64) -> String {
-    let url_ask_stream = format!("https://www.storytel.com/mp3streamRangeReq\
+    let url_ask_stream = format!(
+        "https://www.storytel.com/mp3streamRangeReq\
                                  ?startposition=0&programId={}&token={}",
-                                  id, client_data.login_data.account_info
-                                               .single_sign_token);
+        id, client_data.login_data.account_info.single_sign_token
+    );
 
-    let resp = client_data.request_client.get(&url_ask_stream)
-        .send();
+    let resp = client_data.request_client.get(&url_ask_stream).send();
 
-    resp.as_ref().unwrap().headers().get("location").unwrap().to_str().unwrap()
+    resp.as_ref()
+        .unwrap()
+        .headers()
+        .get("location")
+        .unwrap()
+        .to_str()
+        .unwrap()
         .to_string()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod client_storytel_api;
+mod mpv;
 mod password_crypt;
 mod tui;
-mod mpv;
 
 fn main() {
     let user_agent: &str = "okhttp/3.12.8";
@@ -10,13 +10,16 @@ fn main() {
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .expect("should be able to build reqwest client");
-    let login_data = client_storytel_api::Login
-                        { account_info: client_storytel_api::AccountInfo {
-                         single_sign_token: String::from("") } };
-    let client_data = client_storytel_api::ClientData
-                        { request_client: client,
-                          login_data: login_data,
-                          mpv_thread: None };
+    let login_data = client_storytel_api::Login {
+        account_info: client_storytel_api::AccountInfo {
+            single_sign_token: String::from(""),
+        },
+    };
+    let client_data = client_storytel_api::ClientData {
+        request_client: client,
+        login_data: login_data,
+        mpv_thread: None,
+    };
 
     let mut siv = cursive::default();
 

--- a/src/mpv.rs
+++ b/src/mpv.rs
@@ -7,21 +7,21 @@ pub fn simple_example(video_path: String) -> std::sync::mpsc::Sender<bool> {
 
         // set option "sid" to "no" (no subtitles)
         // mpv options should be set before initializing
-        mpv_builder.set_option("sid","no").unwrap();
+        mpv_builder.set_option("sid", "no").unwrap();
 
         // enable On Screen Controller (disabled with libmpv by default)
-        mpv_builder.set_option("osc",true).unwrap();
+        mpv_builder.set_option("osc", true).unwrap();
 
         let mut mpv = mpv_builder.build().expect("Failed to build MPV handler");
 
         mpv.command(&["loadfile", video_path.as_str()])
-           .expect("Error loading file");
+            .expect("Error loading file");
 
         // loop twice, send parameter as a string
-        mpv.set_property("loop","2").unwrap();
+        mpv.set_property("loop", "2").unwrap();
 
         // set speed to 100%, send parameter as a f64
-        mpv.set_property("speed",1.0).unwrap();
+        mpv.set_property("speed", 1.0).unwrap();
 
         'main: loop {
             while let Some(event) = mpv.wait_event(0.0) {

--- a/src/password_crypt.rs
+++ b/src/password_crypt.rs
@@ -13,10 +13,14 @@ fn pad(password: &str) -> String {
     if module != 0 {
         let pad_length = BLOCK_SIZE - module;
 
-        padded_password = format!("{}{}", password,
-                                      pad_length.to_string()
-                                      .repeat(pad_length.try_into().unwrap())
-                                      .as_str());
+        padded_password = format!(
+            "{}{}",
+            password,
+            pad_length
+                .to_string()
+                .repeat(pad_length.try_into().unwrap())
+                .as_str()
+        );
     }
 
     return padded_password;
@@ -36,4 +40,3 @@ pub fn encrypt_password(password: &str) -> String {
 
     return hex;
 }
-

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,18 +1,14 @@
-use cursive::views::{Dialog, EditView, TextView, LinearLayout, Button,
-                     SelectView};
 use cursive::traits::*;
+use cursive::views::{Button, Dialog, EditView, LinearLayout, SelectView, TextView};
 use cursive::Cursive;
 
 use crate::{client_storytel_api, mpv};
 
 fn show_player(siv: &mut Cursive, book_id: &u64) {
-    let client_data =
-        siv.user_data::<client_storytel_api::ClientData>().unwrap();
-    let url_ask_stream = client_storytel_api::get_stream_url(client_data,
-                                                             book_id);
+    let client_data = siv.user_data::<client_storytel_api::ClientData>().unwrap();
+    let url_ask_stream = client_storytel_api::get_stream_url(client_data, book_id);
 
-    let resp = client_data.request_client.get(&url_ask_stream)
-        .send();
+    let resp = client_data.request_client.get(&url_ask_stream).send();
 
     let location = resp.as_ref().unwrap().url().to_owned().into_string();
 
@@ -25,24 +21,21 @@ fn show_player(siv: &mut Cursive, book_id: &u64) {
 
 fn show_bookshelf(siv: &mut Cursive) {
     let bookshelf = client_storytel_api::get_bookshelf(
-        siv.user_data::<client_storytel_api::ClientData>().unwrap());
+        siv.user_data::<client_storytel_api::ClientData>().unwrap(),
+    );
     siv.pop_layer();
     let mut book_select: Vec<(String, u64)> = Vec::new();
     for book_entry in bookshelf.books.iter() {
         match &book_entry.abook {
-            Some(abook) => book_select.push((book_entry.book.name.clone(),
-                                             abook.id)),
-            None    => continue,
+            Some(abook) => book_select.push((book_entry.book.name.clone(), abook.id)),
+            None => continue,
         }
         println!("{}", book_entry.book.name);
     }
     let select = SelectView::new()
         .with_all(book_select.into_iter())
         .on_submit(show_player);
-    siv.add_layer(
-        Dialog::around(select.scrollable())
-            .title("Select a book to listen"),
-    );
+    siv.add_layer(Dialog::around(select.scrollable()).title("Select a book to listen"));
 }
 
 fn show_check_login(siv: &mut Cursive, email: &str, pass: &str) {
@@ -53,43 +46,39 @@ fn show_check_login(siv: &mut Cursive, email: &str, pass: &str) {
     } else {
         client_storytel_api::login(
             siv.user_data::<client_storytel_api::ClientData>().unwrap(),
-            email, pass);
+            email,
+            pass,
+        );
         siv.pop_layer();
-        siv.add_layer(Dialog::around(LinearLayout::vertical()
-                .child(Button::new("Bookshelf", show_bookshelf))
-                .child(Button::new("Exit", show_login)))
-            .title("Menu"));
+        siv.add_layer(
+            Dialog::around(
+                LinearLayout::vertical()
+                    .child(Button::new("Bookshelf", show_bookshelf))
+                    .child(Button::new("Exit", show_login)),
+            )
+            .title("Menu"),
+        );
     }
 }
 
 pub fn show_login(siv: &mut Cursive) {
-    siv.add_layer(Dialog::around(LinearLayout::vertical()
-            .child(TextView::new("Email"))
-            .child(
-                EditView::new()
-                    .with_name("email")
-                    .fixed_width(20)
-                )
-            .child(TextView::new("Password"))
-            .child(
-                EditView::new()
-                    .secret()
-                    .with_name("pass")
-                    .fixed_width(20)
-                ))
+    siv.add_layer(
+        Dialog::around(
+            LinearLayout::vertical()
+                .child(TextView::new("Email"))
+                .child(EditView::new().with_name("email").fixed_width(20))
+                .child(TextView::new("Password"))
+                .child(EditView::new().secret().with_name("pass").fixed_width(20)),
+        )
         .button("Ok", |s| {
-                let email = s
-                    .call_on_name("email", |view: &mut EditView| {
-                        view.get_content()
-                    })
-                    .unwrap();
-                let pass = s
-                    .call_on_name("pass", |view: &mut EditView| {
-                        view.get_content()
-                    })
-                    .unwrap();
-                show_check_login(s, &email, &pass);
+            let email = s
+                .call_on_name("email", |view: &mut EditView| view.get_content())
+                .unwrap();
+            let pass = s
+                .call_on_name("pass", |view: &mut EditView| view.get_content())
+                .unwrap();
+            show_check_login(s, &email, &pass);
         })
-        .title("Login"));
+        .title("Login"),
+    );
 }
-


### PR DESCRIPTION
Changes:

- Code formatted using [`rustfmt`](https://github.com/rust-lang/rustfmt/) (command: `cargo fmt`). The default settings of this tool follow the [Rust Style Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md).